### PR TITLE
CRAFT-2552 The auto update driver does not play nice with our UI high…

### DIFF
--- a/Sparkle/SUUpdater.m
+++ b/Sparkle/SUUpdater.m
@@ -316,9 +316,20 @@ static NSString *const SUUpdaterDefaultsObservationContext = @"SUUpdaterDefaults
             }
         }
     }
-
+    Class cls = nil;
+    
+    if (automatic) {
+        if ([self.delegate useUserInitiatedUpdateDriverForAutomaticUpdates:self]) {
+            cls = [SUUserInitiatedUpdateDriver class];
+        } else {
+            cls = [SUAutomaticUpdateDriver class];
+        }
+    } else {
+        cls = [SUScheduledUpdateDriver class];
+    }
+    
     // Do not use reachability for a preflight check. This can be deceptive and a bad idea. Apple does not recommend doing it.
-    SUUpdateDriver *theUpdateDriver = [(SUBasicUpdateDriver *)[(automatic ? [SUAutomaticUpdateDriver class] : [SUScheduledUpdateDriver class])alloc] initWithUpdater:self];
+    SUUpdateDriver *theUpdateDriver = [(SUBasicUpdateDriver *)[cls alloc] initWithUpdater:self];
     
     [self checkForUpdatesWithDriver:theUpdateDriver];
 }

--- a/Sparkle/SUUpdaterDelegate.h
+++ b/Sparkle/SUUpdaterDelegate.h
@@ -328,7 +328,7 @@ SU_EXPORT extern NSString *const SUUpdaterItemKey;
 - (BOOL)updaterShouldAutoupdate:(SUUpdater *)updater;
 
 - (BOOL)updaterShouldShowErrors:(SUUpdater *)updater;
-
+- (BOOL) useUserInitiatedUpdateDriverForAutomaticUpdates:(SUUpdater *)updater;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
This PR lets the delegate choose if the SUUserInitiatedUpdateDriver should be used, or the SUAutomaticUpdateDriver when updating.